### PR TITLE
Update Node requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "url": "git+https://github.com/nekomy/nekomy-platform"
   },
   "author": "Nekomy <hello@nekomy.com> (http://nekomy.com)",
+  "engines": {
+    "node": ">=18"
+  },
   "license": "GPL-2.0",
   "dependencies": {
     "axios": "^0.14.0",

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ New project's website (under construction): [Realtime E-Learning](https://e-lear
 
 You need a Unix PC to clone this webapp!
 
-- Install Node.js >= 7.4.0 [https://nodejs.org/](https://nodejs.org/)
+- Install Node.js 18 or later from [https://nodejs.org/](https://nodejs.org/)
 
 - Install a Git client. I recommend SourceTree [https://www.sourcetreeapp.com/](https://www.sourcetreeapp.com/)
 


### PR DESCRIPTION
## Summary
- update README instructions with Node.js 18+
- define an `engines` field requiring Node 18 or newer

## Testing
- `npm run lint`