### PR TITLE
Fix npm dev startup by removing outdated overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,10 +87,5 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.2",
     "webpack-version-file-plugin": "^0.2.2"
-  },
-"overrides": {
-  "ajv": "6.12.6",
-  "ajv-formats": "2.1.1",
-  "ajv-keywords": "3.5.2"
   }
 }


### PR DESCRIPTION
## Summary
- remove `ajv` overrides in `package.json`

This lets webpack-dev-server use the correct versions of `ajv` dependencies.

## Testing
- `node -e "require('./package.json'); console.log('ok');"`