### PR TITLE
Fix install errors by dropping react-hot-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "react-dom": "^18.2.0",
         "react-ga": "^3.3.0",
         "react-helmet": "^6.1.0",
-        "react-hot-loader": "^4.13.0",
         "react-redux": "^8.1.2",
         "react-router-dom": "^6.14.2",
         "react-select2-wrapper": "^1.0.4-beta2",
@@ -13532,44 +13531,6 @@
       },
       "peerDependencies": {
         "react": ">=16.3.0"
-      }
-    },
-    "node_modules/react-hot-loader": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.1.tgz",
-      "integrity": "sha512-ZlqCfVRqDJmMXTulUGic4lN7Ic1SXgHAFw7y/Jb7t25GBgTR0fYAJ8uY4mrpxjRyWGWmqw77qJQGnYbzCvBU7g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^2.0.3",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "@types/react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-hot-loader/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-dom": "^18.2.0",
     "react-ga": "^3.3.0",
     "react-helmet": "^6.1.0",
-    "react-hot-loader": "^4.13.0",
     "react-redux": "^8.1.2",
     "react-router-dom": "^6.14.2",
     "react-select2-wrapper": "^1.0.4-beta2",
@@ -87,10 +86,5 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.2",
     "webpack-version-file-plugin": "^0.2.2"
-  },
-"overrides": {
-  "ajv": "6.12.6",
-  "ajv-formats": "2.1.1",
-  "ajv-keywords": "3.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7210,19 +7210,6 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hot-loader@^4.13.0:
-  version "4.13.1"
-  resolved "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.1.tgz"
-  integrity sha512-ZlqCfVRqDJmMXTulUGic4lN7Ic1SXgHAFw7y/Jb7t25GBgTR0fYAJ8uY4mrpxjRyWGWmqw77qJQGnYbzCvBU7g==
-  dependencies:
-    fast-levenshtein "^2.0.6"
-    global "^4.3.0"
-    hoist-non-react-statics "^3.3.0"
-    loader-utils "^2.0.3"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.1.0"
-    source-map "^0.7.3"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## Summary
- remove unused `react-hot-loader` dependency

This eliminates a peer dependency conflict with React 18 that blocked `npm install`.

## Testing
- `node -e "require('./package.json'); console.log('ok');"`
