### PR TITLE
Fix String capitalize method

### DIFF
--- a/src/app/core/common/helpers.jsx
+++ b/src/app/core/common/helpers.jsx
@@ -9,7 +9,9 @@ import Course from '../../../../static/svg/course.svg';
 import Users from '../../../../static/svg/users.svg';
 
 // String capitalization
-String.prototype.capitalize = () => (this ? this.charAt(0).toUpperCase() + this.slice(1) : null);
+String.prototype.capitalize = function capitalize() {
+  return this ? this.charAt(0).toUpperCase() + this.slice(1) : null;
+};
 
 // Common app methods
 module.exports = {


### PR DESCRIPTION
## Summary
- use normal function for `String.prototype.capitalize`

## Testing
- `npm run lint` *(fails: No files matching the pattern "test" were found)*