### PR TITLE
Fix js loader regex

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = (options) => {
     module: {
       rules: [
         {
-          test: /.jsx?$/,
+          test: /\.jsx?$/,
           include: Path.resolve(__dirname, '../src/app'),
           use: 'babel-loader',
           exclude: /node_modules/


### PR DESCRIPTION
## Summary
- correct js regex in webpack config

## Testing
- `npm run lint` *(fails: no test pattern)*