### PR TITLE
Fix copy-to-clipboard helper

### DIFF
--- a/src/app/core/common/helpers.jsx
+++ b/src/app/core/common/helpers.jsx
@@ -103,6 +103,7 @@ module.exports = {
 
     document.body.appendChild(textArea);
     textArea.select();
+    document.execCommand('copy');
 
     document.body.removeChild(textArea);
   },


### PR DESCRIPTION
## Summary
- ensure `copyTextToClipboard` actually copies text by calling `document.execCommand('copy')`

## Testing
- `npm run lint` *(fails: No files matching the pattern "test" were found)*
- `npm test` *(fails: Missing script: "test")*