### PR TITLE
Add .npmrc for legacy peer deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- add `.npmrc` enabling `legacy-peer-deps`

## Testing
- `npm install` *(fails: unable to access network)*